### PR TITLE
keep the output token in the url

### DIFF
--- a/packages/hippodrome-ui/src/App.tsx
+++ b/packages/hippodrome-ui/src/App.tsx
@@ -13,7 +13,7 @@ export const App = () => (
       <Router>
         <Layout>
           <Switch>
-            <Route path="/transaction/mint/:asset/:to/:nonce" exact>
+            <Route path="/transaction/mint/:asset/:to/:nonce/:outputToken" exact>
               <LockAndMint />
             </Route>
             <Route path="/">

--- a/packages/hippodrome-ui/src/components/swap/Swap.tsx
+++ b/packages/hippodrome-ui/src/components/swap/Swap.tsx
@@ -43,8 +43,6 @@ const Swap: React.FC = () => {
     return getNextNonce();
   }, []);
 
-  // const { getOutput } = useRenOutput(inputToken as KnownInputChains);
-
   const onSubmit = async () => {
     setSubmitting(true);
     try {
@@ -52,8 +50,9 @@ const Swap: React.FC = () => {
         lockNetwork: inputToken as KnownInputChains,
         to: safeAddress!,
         nonce,
+        outputToken,
       });
-      history.push(mintUrl(inputToken, safeAddress!, nonce));
+      history.push(mintUrl(inputToken, safeAddress!, nonce, outputToken));
     } catch (err) {
       console.error("error: ", err);
       alert("something went wrong");

--- a/packages/hippodrome-ui/src/models/ren.ts
+++ b/packages/hippodrome-ui/src/models/ren.ts
@@ -17,11 +17,12 @@ export interface LockAndMintParams {
   lockNetwork: KnownInputChains;
   to: string;
   nonce: number;
+  outputToken: string; // address of output token (only used by hippodrome and not ren)
 }
 
 export type KnownInputChains = "BTC" | "DOGE";
 
-const ren = new RenJS(isTestnet ? "testnet" : undefined); // TODO: support testnet
+const ren = new RenJS(isTestnet ? "testnet" : undefined);
 
 export const NETWORKS = {
   BTC: Bitcoin(isTestnet ? "testnet" : undefined),

--- a/packages/hippodrome-ui/src/pages/LockAndMint.tsx
+++ b/packages/hippodrome-ui/src/pages/LockAndMint.tsx
@@ -7,8 +7,8 @@ import AwaitingDeposit from '../components/transaction/AwaitingDeposit'
 import AwaitingMint from '../components/transaction/AwaitingMint'
 
 const Transaction:React.FC = () => {
-  const { asset, to, nonce } = useParams<{asset:KnownInputChains, to: string, nonce:string}>()
-  const { lockAndMint, deposits, loading } = useLockAndMint({ lockNetwork: asset, to, nonce: parseInt(nonce) })
+  const { asset, to, nonce, outputToken } = useParams<{asset:KnownInputChains, to: string, nonce:string, outputToken:string}>()
+  const { lockAndMint, deposits, loading } = useLockAndMint({ lockNetwork: asset, to, nonce: parseInt(nonce), outputToken })
 
   if (loading) {
     return (

--- a/packages/hippodrome-ui/src/utils/urls.ts
+++ b/packages/hippodrome-ui/src/utils/urls.ts
@@ -1,3 +1,3 @@
-export const mintUrl = (asset:string, to: string, nonce:number) => {
-  return `/transaction/mint/${asset}/${to}/${nonce}`
+export const mintUrl = (asset:string, to: string, nonce:number, outputToken:string) => {
+  return `/transaction/mint/${asset}/${to}/${nonce}/${outputToken}`
 }


### PR DESCRIPTION
this keeps the output token in the URL so at the end of the process we still know where the user intended to swap to