### PR TITLE
easier PTG

### DIFF
--- a/packages/hippodrome-ui/src/App.tsx
+++ b/packages/hippodrome-ui/src/App.tsx
@@ -1,34 +1,51 @@
-import * as React from "react"
-import { ChakraProvider } from "@chakra-ui/react"
-import { BrowserRouter as Router, Switch, Route } from "react-router-dom"
-import Layout from "./layouts/Layout"
-import Swap from "./pages/Swap"
-import Stake from "./pages/Stake"
-import { ChainProvider } from "./hooks/useChainContext"
-import LockAndMint from "./pages/LockAndMint"
-import theme from "./theme"
+import * as React from "react";
+import { ChakraProvider } from "@chakra-ui/react";
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  RouteProps,
+} from "react-router-dom";
+import Layout from "./layouts/Layout";
+import Swap from "./pages/Swap";
+import Stake from "./pages/Stake";
+import { ChainProvider } from "./hooks/useChainContext";
+import LockAndMint from "./pages/LockAndMint";
+import theme from "./theme";
 
-export const App = () => (
+interface RouteWithLayoutParams extends RouteProps {}
+
+const RouteWithLayout: React.FC<RouteWithLayoutParams> = (userProps) => {
+  const { children, ...props } = userProps;
+  return (
+    <Route {...props}>
+      <Layout>{children}</Layout>
+    </Route>
+  );
+};
+
+export const App: React.FC = () => (
   <ChakraProvider theme={theme}>
     <ChainProvider>
       <Router>
-        <Layout>
-          <Switch>
-            <Route path="/transaction/mint/:asset/:to/:nonce" exact>
-              <LockAndMint />
-            </Route>
-            <Route path="/stake">
-              <Stake />
-            </Route>
-            <Route path="/ptg">
-              <Swap />
-            </Route>
-            <Route path="/">
-              <Swap />
-            </Route>
-          </Switch>
-        </Layout>
+        <Switch>
+          <RouteWithLayout path="/transaction/mint/:asset/:to/:nonce" exact>
+            <LockAndMint />
+          </RouteWithLayout>
+          <RouteWithLayout path="/stake">
+            <Stake />
+          </RouteWithLayout>
+          <RouteWithLayout path="/" exact>
+            <Swap />
+          </RouteWithLayout>
+          <RouteWithLayout path="/ptg/:to">
+            <Swap />
+          </RouteWithLayout>
+          <RouteWithLayout path="/ptg">
+            <Swap />
+          </RouteWithLayout>
+        </Switch>
       </Router>
     </ChainProvider>
   </ChakraProvider>
-)
+);

--- a/packages/hippodrome-ui/src/components/PTGSplashScreen.tsx
+++ b/packages/hippodrome-ui/src/components/PTGSplashScreen.tsx
@@ -2,8 +2,13 @@ import { Heading, Text, VStack, Box, Link } from "@chakra-ui/react"
 import React from "react"
 import "@fontsource/zen-dots"
 import ConnectButton from "./ConnectButton"
+import { useParams } from "react-router-dom"
 
 const PTGSplashScreen = () => {
+  const params = useParams<{to: string}>()
+  console.log(params)
+  const { to } = params
+
   return (
     <VStack paddingX="200px" spacing="16">
       <VStack paddingX="100px" spacing="20">
@@ -25,8 +30,8 @@ const PTGSplashScreen = () => {
             or{" "}
             <Box as="span" color="brandOrange.500">
               Dogecoin
-            </Box>{" "}
-            to get{" "}
+            </Box>{" "}<br />
+            for{" "}
             <Box as="span" color="brandOrange.500">
               PTG
             </Box>
@@ -43,8 +48,11 @@ const PTGSplashScreen = () => {
               Crypto Colossuem
             </Link>
           </Text>
+          <ConnectButton text="Get PTG now" />
+          {to && 
+            <p>Game wallet: {to}</p>
+          }
         </VStack>
-        <ConnectButton text="Swap token now" />
       </VStack>
     </VStack>
   )

--- a/packages/hippodrome-ui/src/components/SplashScreens.tsx
+++ b/packages/hippodrome-ui/src/components/SplashScreens.tsx
@@ -1,55 +1,9 @@
-import { Heading, Text, VStack, Box, Grid, Image } from "@chakra-ui/react"
+import { Heading, Text, VStack, Box } from "@chakra-ui/react"
 import React from "react"
 import "@fontsource/zen-dots"
-import coinsImage from "../assets/coins.svg"
 import ConnectButton from "./ConnectButton"
 
 const SplashScreen = () => {
-  const features = [
-    {
-      icon: coinsImage,
-      title: (
-        <Heading
-          as="h3"
-          lineHeight="160%"
-          padding="22px 0px 12px"
-          fontSize="20px"
-        >
-          Swap{" "}
-          <Box as="span" color="brandOrange.500">
-            Bitcoin or Dogecoin
-          </Box>{" "}
-          for any token on Polygon
-        </Heading>
-      ),
-      description: "Send BTC or DOGE and receive any token on Polygon.",
-    },
-    {
-      icon: coinsImage,
-      title: (
-        <Heading
-          as="h3"
-          lineHeight="160%"
-          fontSize="20px"
-          padding="22px 0px 12px"
-        >
-          <Box as="span" color="brandOrange.500">
-            Zap
-          </Box>{" "}
-          from{" "}
-          <Box as="span" color="brandOrange.500">
-            BTC or DOGE
-          </Box>{" "}
-          directly into selected liquidity pools and{" "}
-          <Box as="span" color="brandOrange.500">
-            earn
-          </Box>
-        </Heading>
-      ),
-      description: "Go directly from BTC or DOGE into interest earning DeFi.",
-    },
-  ]
-
   return (
     <VStack paddingX="200px" spacing="16">
       <VStack paddingX="100px" spacing="6">
@@ -63,38 +17,26 @@ const SplashScreen = () => {
           fontWeight="normal"
           textAlign="center"
         >
-          Get your{" "}
+          Swap{" "}
           <Box as="span" color="brandOrange.500">
-            value
+            Bitcoin
+          </Box>
+          {" "}or{" "}
+          <Box as="span" color="brandOrange.500">
+            Dogecoin
           </Box>{" "}
-          onto the{" "}
+          for tokens on the{" "}
           <Box as="span" color="brandOrange.500">
             Polygon
           </Box>{" "}
           Network
         </Heading>
         <Text fontSize="18px" color="gray.200" align="center">
-          The cheapest and easiest way to participate in decentralized finance
-          on the Polygon network.
+          The cheapest and easiest way to move value
+          onto the Polygon network.
         </Text>
-        <ConnectButton text="Swap token now" />
+        <ConnectButton text="Get started" />
       </VStack>
-
-      <Grid templateColumns="repeat(2, 1fr)" gap={6}>
-        {features.map((feature) => (
-          <Box
-            key={feature.description}
-            borderRadius="24px"
-            background="cardBackground"
-            border="1px solid #261C1A"
-            padding="34px"
-          >
-            <Image src={feature.icon} alt="symbol" />
-            {feature.title}
-            <Text>{feature.description}</Text>
-          </Box>
-        ))}
-      </Grid>
     </VStack>
   )
 }

--- a/packages/hippodrome-ui/src/components/swap/Swap.tsx
+++ b/packages/hippodrome-ui/src/components/swap/Swap.tsx
@@ -26,7 +26,7 @@ import {
 } from "../../models/tokenList"
 import SwapFees from "./SwapFees"
 import { parseValueToHex } from "../../utils/parse"
-import { useHistory } from "react-router-dom"
+import { useHistory, useParams } from "react-router-dom"
 import { mintUrl } from "../../utils/urls"
 import { useMemo } from "react"
 import { useChainContext } from "../../hooks/useChainContext"
@@ -34,9 +34,11 @@ import { useRenOutput } from "../../hooks/useRen"
 import { constants } from "ethers"
 
 const Swap: React.FC = () => {
+  const { to } = useParams<{to: string}>()
+
   const { safeAddress, chain } = useChainContext()
   const [amount, setAmount] = useState(0)
-  const [inputToken, setInputToken] = useState("DOGE")
+  const [inputToken, setInputToken] = useState("BTC")
   const history = useHistory()
   const [outputToken, setOutputToken] = useState(
     "0xc0f14c88250e680ecd70224b7fba82b7c6560d12" // wPTG
@@ -72,7 +74,8 @@ const Swap: React.FC = () => {
         inputToken, 
         to: safeAddress!,
         nonce, 
-        swap: outputToken
+        swap: outputToken,
+        forwardTo: to,
       }))
     } catch (err) {
       console.error("error: ", err)
@@ -97,7 +100,7 @@ const Swap: React.FC = () => {
           Convert {selectedInputToken?.symbol} to {selectedOutputToken?.name}
         </Heading>
         <SmallText fontSize="10" color="gray.400">
-          Converted coins are on Polygon Network
+          Received coins are on the Polygon network
         </SmallText>
       </VStack>
 
@@ -161,6 +164,22 @@ const Swap: React.FC = () => {
             />
           </HStack>
         </Box>
+        {to && (
+          <Box 
+            w="100%" 
+          >
+            <SmallText>To Wallet:</SmallText>
+            <Box
+              background="gray.900"
+              px="3"
+              py="3"
+              marginTop="3"
+              rounded="lg" 
+            >
+              {to}
+            </Box>
+          </Box>
+        )}
       </VStack>
 
       <SwapFees

--- a/packages/hippodrome-ui/src/components/transaction/AwaitingMint.tsx
+++ b/packages/hippodrome-ui/src/components/transaction/AwaitingMint.tsx
@@ -49,7 +49,7 @@ interface DepositConfirmedProps {
 const DepositSwapConfirmed: React.FC<DepositConfirmedProps> = ({
   propDeposit,
 }) => {
-  const { address } = useChainContext()
+  const { address:userSignerAddress } = useChainContext()
   const { deposit, confirmations } = useDeposit(propDeposit)
   const [loading, setLoading] = useState(false)
   const toast = useToast()
@@ -57,6 +57,8 @@ const DepositSwapConfirmed: React.FC<DepositConfirmedProps> = ({
 
   const networkName = deposit.lockAndMint.params.lockNetwork
   const depositAmount = deposit.deposit.depositDetails.amount
+
+  const forwardTo = deposit.lockAndMint.params.forwardTo || userSignerAddress
 
   const { output: renOutput } = useRenOutput(
     deposit.lockAndMint.params.lockNetwork,
@@ -178,10 +180,10 @@ const DepositSwapConfirmed: React.FC<DepositConfirmedProps> = ({
             title={deposit.lockAndMint.params.to}
           >
             <Box h={8} w={8}>
-              <Jazzicon address={address!} />
+              <Jazzicon address={forwardTo!} />
             </Box>
             <Text fontWeight="semibold">
-              {centeredTruncateText(address!, 15)}
+              {centeredTruncateText(forwardTo!, 15)}
             </Text>
           </HStack>
         </Box>
@@ -343,7 +345,7 @@ const Deposit: React.FC<{ deposit: WrappedLockAndMintDeposit }> = ({
   }
 
   return (
-    <VStack spacing="4">
+    <VStack spacing="4" textAlign="center">
       <motion.div
         animate={{
           scale: [1, 1.1, 1],
@@ -366,11 +368,11 @@ const Deposit: React.FC<{ deposit: WrappedLockAndMintDeposit }> = ({
           </CircularProgressLabel>
         </CircularProgress>
       </motion.div>
-      <Heading>Waiting for {confirmations?.target} confirmations</Heading>
-      {/* TODO: give the user an estimate of time */}
+      <Heading>Waiting for<br />{confirmations?.target} confirmations</Heading>
+      <Text>Do not close this tab.</Text>
       <Text>
-        We need to wait for the miners on the chain to confirm your transaction.
-        This could take a little while.
+        The miners need to confirm your transaction.<br />
+        This usually takes between 30 and 90 minutes.
       </Text>
     </VStack>
   )

--- a/packages/hippodrome-ui/src/layouts/Layout.tsx
+++ b/packages/hippodrome-ui/src/layouts/Layout.tsx
@@ -1,4 +1,4 @@
-import { Text, Image, HStack, Link, Heading, VStack } from "@chakra-ui/react"
+import { Text, Image, HStack, Link, Heading, VStack, Box } from "@chakra-ui/react"
 import { ExternalLinkIcon } from "@chakra-ui/icons"
 import React from "react"
 import { useLocation, Link as RouterLink } from "react-router-dom"
@@ -25,10 +25,6 @@ const navLinks: NavLink[] = [
   {
     title: "Swap",
     link: "/",
-  },
-  {
-    title: "earn",
-    link: "/stake",
   },
 ]
 
@@ -97,20 +93,20 @@ const Layout: React.FC = ({ children }) => {
       </HStack>
 
       {!address && (
-        <>
-          {location.pathname === "/ptg" ? (
+        <Box pb="100">
+          {location.pathname.startsWith("/ptg") ? (
             <PTGSplashScreen />
           ) : (
             <SplashScreen />
           )}
-        </>
+        </Box>
       )}
       {address && supportedNetworks.includes(chain.chainId!) && children}
       {address && !supportedNetworks.includes(chain.chainId!) && (
         <WrongNetwork />
       )}
 
-      <VStack mt="10" spacing="8" flexGrow={1} justifyContent="center">
+      <VStack spacing="8" flexGrow={1} justifyContent="center">
         <Heading size="sm">Powered by</Heading>
         <HStack spacing="8">
           <a

--- a/packages/hippodrome-ui/src/models/ren.ts
+++ b/packages/hippodrome-ui/src/models/ren.ts
@@ -48,6 +48,7 @@ export interface LockAndMintParams {
   to: string;
   nonce: number;
   outputToken: string; // address of output token (only used by hippodrome and not ren)
+  forwardTo?: string;
 }
 
 export type KnownInputChains = "BTC" | "DOGE";

--- a/packages/hippodrome-ui/src/pages/LockAndMint.tsx
+++ b/packages/hippodrome-ui/src/pages/LockAndMint.tsx
@@ -15,12 +15,14 @@ const Transaction: React.FC = () => {
   }>()
   const query = useQuery()
   const swap = query.get("swap")
+  const forwardTo = query.get("forwardTo") || undefined
 
   const { lockAndMint, deposits, loading } = useLockAndMint({
     lockNetwork: asset,
     to,
     nonce: parseInt(nonce),
     outputToken: (swap || ''),
+    forwardTo,
   })
 
   if (loading) {

--- a/packages/hippodrome-ui/src/utils/urls.ts
+++ b/packages/hippodrome-ui/src/utils/urls.ts
@@ -4,11 +4,12 @@ export interface MintUrlParams {
   nonce: number;
   swap?: string;
   pool?: string;
+  forwardTo?: string;
 }
 
-export const mintUrl = ({ inputToken, to, nonce, swap, pool }: MintUrlParams) => {
+export const mintUrl = ({ inputToken, to, nonce, swap, pool, forwardTo }: MintUrlParams) => {
   if (swap) {
-    return `/transaction/mint/${inputToken}/${to}/${nonce}?swap=${swap}`;
+    return `/transaction/mint/${inputToken}/${to}/${nonce}?swap=${swap}&forwardTo=${forwardTo}`;
   }
   return `/transaction/mint/${inputToken}/${to}/${nonce}?pool=${pool}`;
 };

--- a/packages/hippodrome-ui/yarn.lock
+++ b/packages/hippodrome-ui/yarn.lock
@@ -5198,9 +5198,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
-  version "1.0.30001191"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001191.tgz"
-  integrity sha512-xJJqzyd+7GCJXkcoBiQ1GuxEiOBCLQ0aVW9HMekifZsAVGdj5eJ4mFB9fEhSHipq9IOk/QXFJUiIr9lZT+EsGw==
+  version "1.0.30001261"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001261.tgz"
+  integrity sha512-vM8D9Uvp7bHIN0fZ2KQ4wnmYFpJo/Etb4Vwsuc+ka0tfGDHvOPrFm6S/7CCNLSOkAUjenT2HnUPESdOIL91FaA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This lets hippodrome go directly to your game wallet (still WPTG for now). But skips the step of having to have MATIC in your torus / metamask.

Also:

* remove links to 'earn'
* streamline language on the splash pages.