### PR TITLE
bad url was showig up as forwardTo=undefined

### DIFF
--- a/packages/hippodrome-ui/src/utils/urls.ts
+++ b/packages/hippodrome-ui/src/utils/urls.ts
@@ -9,7 +9,8 @@ export interface MintUrlParams {
 
 export const mintUrl = ({ inputToken, to, nonce, swap, pool, forwardTo }: MintUrlParams) => {
   if (swap) {
-    return `/transaction/mint/${inputToken}/${to}/${nonce}?swap=${swap}&forwardTo=${forwardTo}`;
+    const forwardToStr = forwardTo ? `&forwardTo=${forwardTo}` : ''
+    return `/transaction/mint/${inputToken}/${to}/${nonce}?swap=${swap}${forwardToStr}`;
   }
   return `/transaction/mint/${inputToken}/${to}/${nonce}?pool=${pool}`;
 };


### PR DESCRIPTION
and that was preventing swapping. now it will only append the forwardTo when it's actually present.